### PR TITLE
remove site_id from siteconfigs and system_id from access_credentials

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -13,7 +13,6 @@ class AccessCredentials(Model):
     id = columns.UUID(primary_key=True, default=uuid.uuid1)
     conn_string = columns.Text(required=True)
     name = columns.Text(required=True)
-    system_id = columns.UUID(required=True, index=True)
 
     is_active = columns.Boolean(required=True, default=True)
     created_at = columns.DateTime(required=True, default=datetime.utcnow())
@@ -172,7 +171,6 @@ class SiteConfig(Model):
     id = columns.UUID(primary_key=True, default=uuid.uuid1)
     site_name = columns.Text(required=True, index=True)
     site_code = columns.Text(required=True, index=True)
-    site_id = columns.UUID(required=False, index=True)
     primary_system = columns.Text(required=True)
     other_systems = columns.Text(required=False)
     is_active = columns.Boolean(required=True, default=False)


### PR DESCRIPTION
## Summary by Sourcery

Remove unnecessary fields 'system_id' from AccessCredentials and 'site_id' from SiteConfig models to streamline data models.

Enhancements:
- Remove the 'system_id' field from the AccessCredentials model.
- Remove the 'site_id' field from the SiteConfig model.